### PR TITLE
Make straight line visualization more consistent

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -17,7 +17,7 @@
   st = status
   br = branch
   branches = for-each-ref --sort=-committerdate --format=\"%(color:blue)%(authordate:relative)\t%(color:red)%(authorname)\t%(color:white)%(color:bold)%(refname:short)\" refs/remotes
-  lg = log --graph --abbrev-commit --decorate --format=format:'%C(bold blue)%h%C(reset) - %C(bold cyan)%aD%C(dim white) - %an%C(reset) %C(bold green)(%ar)%C(reset)%C(bold yellow)%d%C(reset)%n %C(white)%s%C(reset)'
+  lg = log --abbrev-commit --decorate --format=format:'* %C(bold blue)%h%C(reset) - %C(bold cyan)%aD%C(dim white) - %an%C(reset) %C(bold green)(%ar)%C(reset)%C(bold yellow)%d%C(reset)%n%C(red)|%C(reset)  %C(white)%s%C(reset)'
 [commit]
 [heroku]
   account = codeguy


### PR DESCRIPTION
As written, `git lg` sometimes wouldn't output a straight line despite `git` being used properly.

This fixes the `git lg` alias to always show the desired straight line.

:kissing: